### PR TITLE
Fix usage() to show default values properly

### DIFF
--- a/mpssh.c
+++ b/mpssh.c
@@ -165,19 +165,19 @@ usage(char *msg)
 	    printf("\n Usage: mpssh [-u username] [-p numprocs] [-f hostlist]\n"
 		"              [-e] [-b] [-o /some/dir] [-s] [-v] <command>\n\n"
 		"  -b, --blind       Enable blind mode (no remote output)\n"
-		"  -d, --delay       Delay between each ssh fork in milisecs\n"
+		"  -d, --delay       Delay between each ssh fork (default %d msec)\n"
 		"  -e, --exit        Print the remote command return code\n"
 		"  -f, --file=FILE   Name of the file with the list of hosts\n"
 		"  -h, --help        This screen\n"
 		"  -l, --label=LABEL Connect only to hosts under label LABEL\n"
 		"  -o, --outdir=DIR  Save the remote output in this directory\n"
-		"  -p, --procs=NPROC Number of parallel ssh processes\n"
+		"  -p, --procs=NPROC Number of parallel ssh processes (default %d)\n"
 		"  -s, --nokeychk    Disable ssh strict host key check\n"
-		"  -t, --conntmout   Ssh connect timeout (default 30sec)\n"
+		"  -t, --conntmout   Ssh connect timeout (default %d sec)\n"
 		"  -u, --user=USER   Ssh login as this username\n"
 		"  -v, --verbose     Be more verbose and show progress\n"
 		"  -V, --version     Show program version\n"
-		"\n");
+		"\n", delay, DEFCHLD, ssh_conn_tmout);
 	} else {
 		printf("\n   *** %s\n\n", msg);
 	}


### PR DESCRIPTION
Hi,

I noticed you've hard-coded the "default 30sec" for the "Ssh connect timeout" in usage(), so I decided to make it reflect the actual default in a dynamic way -- by getting the value from the global variable.

Then I noticed that some default values weren't displayed in the usage(). All those have been added too.

I've got some more fixes to commit+merge later but first we need to discuss them:
1. Let's set the default delay between each ssh fork to 10 msec?
   For 500 servers this slows down the whole process only with 5 seconds, but at the same time doesn't bombard your local machine with hundreds of fork()'s at once.
2. The new "[ user@server ]" output is kinda uncomfortable for us (me, zImage, and the automated scripts at work) and we want the old behavior back :-) Furthermore, 99% of people are probably using mass SSH executions via a single username for all sessions.
   The questions:
   - Do we make the plain server-only output default and add an argument option to make it more verbose as it is now?
   - Or do we make an argument option to make it less verbose (and thus revert to the old server-only output)?
   - If you have any preference, provide the short and long argument name to use.
