### PR TITLE
By default use the ssh configured port for this host (not always 22)

### DIFF
--- a/host.c
+++ b/host.c
@@ -199,7 +199,7 @@ host_readlist(char *fname)
 
         hostname = line;
         login = NULL;
-        port = SSHDEFPORT;
+        port = NULL;
 
         /* XXX: This is ugly */
         for (i=0; i < linelen; i++) {
@@ -237,9 +237,6 @@ host_readlist(char *fname)
             if (strcmp(llabel, label))
                 continue;
         }
-
-        if (port == 0)
-            continue;
 
         /* add the host record */
         hst = host_add(hst, login, hostname, (uint16_t)port);

--- a/mpssh.c
+++ b/mpssh.c
@@ -158,8 +158,10 @@ child()
     snprintf(user_arg, len_u, "-l%s", ps->hst->user);
     ssh_argv[sap++] = user_arg;
 
-    snprintf(port_arg, sizeof(port_arg), "-p%d", ps->hst->port);
-    ssh_argv[sap++] = port_arg;
+    if (ps->hst->port != NULL) {
+        snprintf(port_arg, sizeof(port_arg), "-p%d", ps->hst->port);
+        ssh_argv[sap++] = port_arg;
+    }
 
     if (ssh_hkey_check)
         ssh_argv[sap++] = "-oStrictHostKeyChecking=yes";
@@ -331,7 +333,7 @@ parse_opts(int *argc, char ***argv)
                 }
                 if (!(S_ISREG(scstat.st_mode) && scstat.st_mode & 0111)) {
                     usage("script file is not executable");
-                }    
+                }
                 base_script = basename(script);
                 break;
             case 's':

--- a/mpssh.h
+++ b/mpssh.h
@@ -50,8 +50,6 @@
 #define SCPPATH "/usr/bin/scp"
 #endif
 
-#define SSHDEFPORT 22
-
 /* Default hosts filename, relative to users homedir */
 #define HSTLIST  ".mpssh/hosts"
 #define MAXCMD   1024                /* max command len */


### PR DESCRIPTION
The default port can be configured using ssh_config file, and not always the default is 22 so this change only pass the port to the ssh when is defined at the hosts file.
