### PR TITLE
Fix local script not working without host port set

### DIFF
--- a/host.h
+++ b/host.h
@@ -27,6 +27,7 @@
 
 #define MAXNAME    255 /* max hostname len */
 #define NON_DEFINED_PORT 0
+#define DEFAULT_PORT 22
 
 /* host list structs */
 struct

--- a/mpssh.c
+++ b/mpssh.c
@@ -174,11 +174,13 @@ child()
 
 
     if (local_command) {
+        snprintf(port_arg, sizeof(port_arg), "-P%d", (ps->hst->port
+            != NON_DEFINED_PORT ? ps->hst->port : DEFAULT_PORT));
         ssh_argv[sap++] = "-oPermitLocalCommand=yes";
         lcmd = calloc(1, 2048);
-        snprintf(lcmd, 2048, "-oLocalCommand=%s -P%d -p %s %s@%s:%s",
+        snprintf(lcmd, 2048, "-oLocalCommand=%s %s -p %s %s@%s:%s",
             SCPPATH,
-            ps->hst->port,
+            port_arg,
             script,
             ps->hst->user,
             ps->hst->host,


### PR DESCRIPTION
Local command formatting sets port to 0 if not explicitly defined with host. This adds a default port which is only used for local commands.
